### PR TITLE
Add strict proxying

### DIFF
--- a/src/test/decorator.spec.ts
+++ b/src/test/decorator.spec.ts
@@ -53,4 +53,63 @@ describe('@RemoteMethodModule Decorator', () => {
       expect(instance).to.have.property('prop', 'goodbye');
     });
   });
+
+  context('strictProxy', () => {
+    let internalModel: any, externalModel: any, decorated: any, instance: any;
+    before('Configure proxy', () => {
+      const app = loopback();
+      internalModel =
+          loopback.Model.extend(`Internal${Date.now()}`, {secret: 'string', prop: 'string'}, {});
+      externalModel = loopback.Model.extend(
+          `External${Date.now()}`, {prop: 'string'},
+          {strict: true, idInjection: false, forceId: false});
+      let memory = loopback.memory();
+      internalModel.attachTo(memory);
+      externalModel.attachTo(memory);
+      app.model(internalModel);
+      app.model(externalModel);
+
+      @RemoteMethodModule({
+        proxyFor: internalModel.modelName,
+        strict: true,
+        proxyMethods: ['find', 'findById', 'create', 'prototype.updateAttributes']
+      })
+      class ModelClass {
+        constructor(public model: any) {}
+      }
+
+      decorated = new ModelClass(externalModel);
+      app.emit('booted');
+    });
+
+    before('Create instances', async () => {
+      instance = await internalModel.create({prop: 'hello'});
+    });
+
+    it('proxies findById to another model returning an instance of the proxy', async () => {
+      let result = await externalModel.findById(instance.id);
+      expect(result).to.be.an.instanceof (externalModel);
+      expect(result).to.have.property('prop', 'hello');
+      expect(result).not.to.have.property('secret');
+    });
+    it('proxies find to another model returning an instance of the proxy', async () => {
+      let result = await externalModel.find();
+      expect(result).to.be.an('array');
+      let item = result[0];
+      expect(item).to.be.an.instanceof (externalModel);
+      expect(item).to.have.property('prop', 'hello');
+      expect(item).not.to.have.property('secret');
+    });
+    it('proxies writes to the underlying model', async () => {
+      let result = await externalModel.findById(instance.id);
+      await result.updateAttributes({prop: 'hi'});
+      let updated = await internalModel.findById(instance.id);
+      expect(updated).to.have.property('prop', 'hi');
+    });
+    it('proxies creation to the underlying model', async () => {
+      let inst = await externalModel.create({prop: 'greetings'});
+      let updated = await internalModel.findById(inst.id);
+      expect(updated).to.have.property('prop', 'greetings');
+    });
+  });
 });


### PR DESCRIPTION
Closes #15 

The use-case for this is effectively stripped-back models in relations.

Let's say I've got a model `User` which has a bunch of properties:
```javascript
{
  firstName: 'string',
  lastName: 'string',
  password: 'string',
  email: 'string',
  creditCardToken: 'string',
  // ...etc
  relations: {  profileImage: { hasOne: 'Image' }   }
}
```

and I have another model `Comment` which `hasMany: 'Users'`. What if I want to return to the client a list of comments along with some basic details about the user that created them. We could just make the comment belong to `User` and include the user - but then you get back all the private server details that shouldn't be accessed as well as redundant data not needed (email).

With strict proxy, this becomes an easy thing to get around:

```javascript
// comment.json
{
  body: 'string',
  relations: { author: { belongsTo: 'UserProfile' } }
}
```
```javascript
// user-profile.json
{
  options: { strict: true } // block out unknown properties
  firstName: 'string',
  lastName: 'string',
  relations: {  profileImage: { hasOne: 'Image' }   }
}
```
```javascript
// user-profile.ts
@RemoteMethodModule({
  proxyFor: 'User',
  proxyMethods: ['find', 'findById', 'create', 'prototype.updateAttributes'],
  strict: true, // this is a strict proxy - returns instances of `UserProfile`
  remoteMethods: []
})
export class UserProfileModule {
  // ...
}
```

Now, when I query on comment:

```javascript
  comment.find({ include: 'author' })
```

The underlying include calls find on the proxy - but since it is a strict proxy, the response you get back is an instance of `UserProfile` not `User` - so `.toJSON()` will come back with only the name and profile image.