### PR TITLE
Replace clang format with prettier

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,3 +1,0 @@
-Language:        JavaScript
-BasedOnStyle:    Google
-ColumnLimit:     100

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+package.json
+package.lock.json
+tools/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "es5"
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,11 @@
 import 'reflect-metadata';
 
-import {createEventMethod} from './lib/create-event';
-import {createRemoteMethod} from './lib/create-remote';
-import {makeDecorator} from './lib/type-decorators';
+import { createEventMethod } from './lib/create-event';
+import { createRemoteMethod } from './lib/create-remote';
+import { makeDecorator } from './lib/type-decorators';
 
-export {Response} from './lib/response';
-export {Validate} from './lib/validate';
+export { Response } from './lib/response';
+export { Validate } from './lib/validate';
 
 /**
  * Configuration fo rthe remote method model
@@ -67,10 +67,12 @@ export function RemoteMethodModule(options: IModuleOptions) {
             (options.proxyMethods || []).forEach(method => {
               if (method.indexOf('prototype.') === 0) {
                 let methodName = method.split('.').pop();
-                Model.prototype[methodName] = async function instance(...args: any[]) {
+                Model.prototype[methodName] = async function instance(
+                  ...args: any[]
+                ) {
                   let instance = this;
                   if (this.toJSON) {
-                    let data = {...this.toJSON()};
+                    let data = { ...this.toJSON() };
                     if (this.isNewRecord()) {
                       data.id = undefined;
                     }
@@ -78,13 +80,21 @@ export function RemoteMethodModule(options: IModuleOptions) {
                     instance.__persisted = this.__persisted;
                   }
                   return await getResult(
-                      ProxyFor.prototype[methodName].bind(instance), Model, options.strict, args);
-                }
+                    ProxyFor.prototype[methodName].bind(instance),
+                    Model,
+                    options.strict,
+                    args
+                  );
+                };
               } else {
                 Model[method] = async function(...args: any[]) {
                   return await getResult(
-                      ProxyFor[method].bind(ProxyFor), Model, options.strict, args);
-                }
+                    ProxyFor[method].bind(ProxyFor),
+                    Model,
+                    options.strict,
+                    args
+                  );
+                };
               }
             });
           });
@@ -106,7 +116,12 @@ export function RemoteMethodModule(options: IModuleOptions) {
   };
 }
 
-async function getResult(callMethod: Function, ProxyModel: any, strict: boolean, args: any[]) {
+async function getResult(
+  callMethod: Function,
+  ProxyModel: any,
+  strict: boolean,
+  args: any[]
+) {
   let cb = getCallback(args);
   if (cb) {
     args = args.slice(0, -1);
@@ -153,7 +168,12 @@ function toProxy(ProxyModel: any, res: any) {
   }
 }
 
-export const RemoteMethod: any =
-    makeDecorator('RemoteMethod', {selector: undefined, meta: undefined, providers: undefined});
-export const ModelEvent: any =
-    makeDecorator('ModelEvent', {selector: undefined, providers: undefined});
+export const RemoteMethod: any = makeDecorator('RemoteMethod', {
+  selector: undefined,
+  meta: undefined,
+  providers: undefined,
+});
+export const ModelEvent: any = makeDecorator('ModelEvent', {
+  selector: undefined,
+  providers: undefined,
+});

--- a/src/lib/create-event.ts
+++ b/src/lib/create-event.ts
@@ -1,13 +1,18 @@
-import {resolve} from './utils';
-export function createEventMethod(RemoteClass: any, RemoteMethod: any, props: any) {
-  let {selector, providers} = props;
+import { resolve } from './utils';
+export function createEventMethod(
+  RemoteClass: any,
+  RemoteMethod: any,
+  props: any
+) {
+  let { selector, providers } = props;
   RemoteClass.on(selector, async function(...args: any[]) {
     let proms = await resolve(RemoteClass, providers);
     let isNull = proms.indexOf(null);
     if (isNull > -1) {
       throw Error(
-          `cannot instantiate ${RemoteMethod.name} provider at position: ${isNull} is null`);
+        `cannot instantiate ${RemoteMethod.name} provider at position: ${isNull} is null`
+      );
     }
     return new RemoteMethod(...proms).onEvent(...args);
-  })
+  });
 }

--- a/src/lib/create-remote.ts
+++ b/src/lib/create-remote.ts
@@ -1,9 +1,13 @@
-import {buildResponse} from './response';
-import {resolve} from './utils';
-import {validateArgs} from './validate';
+import { buildResponse } from './response';
+import { resolve } from './utils';
+import { validateArgs } from './validate';
 
-export function createRemoteMethod(RemoteClass: any, RemoteMethod: any, props: any) {
-  let {selector, meta, providers} = props;
+export function createRemoteMethod(
+  RemoteClass: any,
+  RemoteMethod: any,
+  props: any
+) {
+  let { selector, meta, providers } = props;
   if (meta.isStatic) {
     RemoteClass[selector] = async function(...args: any[]) {
       await validateArgs(args, RemoteMethod);
@@ -12,7 +16,8 @@ export function createRemoteMethod(RemoteClass: any, RemoteMethod: any, props: a
       let isNull = proms.indexOf(null);
       if (isNull > -1) {
         throw Error(
-            `cannot instantiate ${RemoteMethod.name} provider at position: ${isNull} is null`);
+          `cannot instantiate ${RemoteMethod.name} provider at position: ${isNull} is null`
+        );
       }
       let result = await new RemoteMethod(...proms).onRemote(...args);
       return buildResponse(result, RemoteMethod);
@@ -25,7 +30,8 @@ export function createRemoteMethod(RemoteClass: any, RemoteMethod: any, props: a
       let isNull = proms.indexOf(null);
       if (isNull > -1) {
         throw Error(
-            `cannot instantiate ${RemoteMethod.name} provider at position: ${isNull} is null`);
+          `cannot instantiate ${RemoteMethod.name} provider at position: ${isNull} is null`
+        );
       }
 
       let result = await new RemoteMethod(...proms).onRemote(...args);

--- a/src/lib/response.ts
+++ b/src/lib/response.ts
@@ -3,43 +3,64 @@ const loopback = require('loopback');
 
 export abstract class ModelResponseInstance {
   toJSON?: () => {
-    [key: string]: any
+    [key: string]: any;
   };
   [key: string]: any;
 }
 
-export interface IResponseConfig { responseClass: string, isMulti?: boolean }
+export interface IResponseConfig {
+  responseClass: string;
+  isMulti?: boolean;
+}
 
-export function Response(config: string|IResponseConfig|string[]) {
-  return function(target: any, propertyKey: string, descriptor: PropertyDescriptor) {
+export function Response(config: string | IResponseConfig | string[]) {
+  return function(
+    target: any,
+    propertyKey: string,
+    descriptor: PropertyDescriptor
+  ) {
     if (typeof config === 'string') {
-      config = {responseClass: config, isMulti: false};
+      config = { responseClass: config, isMulti: false };
     } else if (Array.isArray(config)) {
-      config = {responseClass: config.pop(), isMulti: true};
+      config = { responseClass: config.pop(), isMulti: true };
     }
-    Reflect.defineMetadata(responseMetadataKey, config, target.constructor, propertyKey);
-  }
+    Reflect.defineMetadata(
+      responseMetadataKey,
+      config,
+      target.constructor,
+      propertyKey
+    );
+  };
 }
 
 export function buildResponse(result: any, RemoteClass: any) {
-  const meta: IResponseConfig =
-      Reflect.getOwnMetadata(responseMetadataKey, RemoteClass, 'onRemote');
+  const meta: IResponseConfig = Reflect.getOwnMetadata(
+    responseMetadataKey,
+    RemoteClass,
+    'onRemote'
+  );
   if (!meta) {
     return result;
   }
 
-  const {isMulti, responseClass} = meta;
+  const { isMulti, responseClass } = meta;
   let ResponseClass;
   ResponseClass = loopback.registry.modelBuilder.models[responseClass];
   if (!ResponseClass) {
-    throw new Error(`No model definition for ${responseClass} found on the registry`);
+    throw new Error(
+      `No model definition for ${responseClass} found on the registry`
+    );
   }
 
-  return isMulti ? result.map(mapResponse.bind(null, ResponseClass)) :
-                   mapResponse(ResponseClass, result);
+  return isMulti
+    ? result.map(mapResponse.bind(null, ResponseClass))
+    : mapResponse(ResponseClass, result);
 }
 
-export function mapResponse(ResponseClass: any, instance: ModelResponseInstance) {
+export function mapResponse(
+  ResponseClass: any,
+  instance: ModelResponseInstance
+) {
   if (typeof instance.toJSON === 'function') {
     return new ResponseClass(instance.toJSON());
   }

--- a/src/lib/type-decorators.ts
+++ b/src/lib/type-decorators.ts
@@ -1,4 +1,3 @@
-
 /**
  * @license
  * Copyright Google Inc. All Rights Reserved.
@@ -24,7 +23,9 @@ export function isType(v: any): v is Type<any> {
   return typeof v === 'function';
 }
 
-export interface Type<T> extends Function { new(...args: any[]): T; }
+export interface Type<T> extends Function {
+  new (...args: any[]): T;
+}
 
 /**
  * @license
@@ -41,15 +42,18 @@ declare var WorkerGlobalScope: any /** TODO #9100 */;
 // we'll just fake the global "global" var for now.
 declare var global: any /** TODO #9100 */;
 const __window = typeof window !== 'undefined' && window;
-const __self = typeof self !== 'undefined' && typeof WorkerGlobalScope !== 'undefined' &&
-    self instanceof WorkerGlobalScope && self;
+const __self =
+  typeof self !== 'undefined' &&
+  typeof WorkerGlobalScope !== 'undefined' &&
+  self instanceof WorkerGlobalScope &&
+  self;
 const __global = typeof global !== 'undefined' && global;
-const _global: {[name: string]: any} = __window || __global || __self;
-export {_global as global};
+const _global: { [name: string]: any } = __window || __global || __self;
+export { _global as global };
 
 // When Symbol.iterator doesn't exist, retrieves the key used in es6-shim
 let _symbolIterator: any = null;
-export function getSymbolIterator(): string|symbol {
+export function getSymbolIterator(): string | symbol {
   if (!_symbolIterator) {
     const Symbol = _global['Symbol'];
     if (Symbol && Symbol.iterator) {
@@ -59,8 +63,11 @@ export function getSymbolIterator(): string|symbol {
       const keys = Object.getOwnPropertyNames(Map.prototype);
       for (let i = 0; i < keys.length; ++i) {
         const key = keys[i];
-        if (key !== 'entries' && key !== 'size' &&
-            (Map as any).prototype[key] === Map.prototype['entries']) {
+        if (
+          key !== 'entries' &&
+          key !== 'size' &&
+          (Map as any).prototype[key] === Map.prototype['entries']
+        ) {
           _symbolIterator = key;
         }
       }
@@ -71,7 +78,10 @@ export function getSymbolIterator(): string|symbol {
 
 // JS has NaN !== NaN
 export function looseIdentical(a: any, b: any): boolean {
-  return a === b || typeof a === 'number' && typeof b === 'number' && isNaN(a) && isNaN(b);
+  return (
+    a === b ||
+    (typeof a === 'number' && typeof b === 'number' && isNaN(a) && isNaN(b))
+  );
 }
 
 export function stringify(token: any): string {
@@ -125,14 +135,13 @@ export type ClassDefinition = {
    * See {@link Class} for example of usage.
    */
   constructor: Function | any[];
-} &
-{
+} & {
   /**
    * Other methods on the class. Note that values should have type 'Function'
    * but TS requires all properties to have a narrower type than the index
    * signature.
    */
-  [x: string]: Type<any>|Function|any[];
+  [x: string]: Type<any> | Function | any[];
 };
 
 /**
@@ -165,7 +174,11 @@ export interface TypeDecorator {
   // ParameterDecorator is declared in lib.d.ts as a `declare type`
   // so we cannot declare this interface as a subtype.
   // see https://github.com/angular/angular/issues/3379#issuecomment-126169417
-  (target: Object, propertyKey?: string|symbol, parameterIndex?: number): void;
+  (
+    target: Object,
+    propertyKey?: string | symbol,
+    parameterIndex?: number
+  ): void;
 
   /**
    * Storage for the accumulated annotations so far used by the DSL syntax.
@@ -182,17 +195,30 @@ export interface TypeDecorator {
 }
 
 function extractAnnotation(annotation: any): any {
-  if (typeof annotation === 'function' && annotation.hasOwnProperty('annotation')) {
+  if (
+    typeof annotation === 'function' &&
+    annotation.hasOwnProperty('annotation')
+  ) {
     // it is a decorator, extract annotation
     annotation = annotation.annotation;
   }
   return annotation;
 }
 
-function applyParams(fnOrArray: Function|any[]|undefined, key: string): Function {
-  if (fnOrArray === Object || fnOrArray === String || fnOrArray === Function ||
-      fnOrArray === Number || fnOrArray === Array) {
-    throw new Error(`Can not use native ${stringify(fnOrArray)} as constructor`);
+function applyParams(
+  fnOrArray: Function | any[] | undefined,
+  key: string
+): Function {
+  if (
+    fnOrArray === Object ||
+    fnOrArray === String ||
+    fnOrArray === Function ||
+    fnOrArray === Number ||
+    fnOrArray === Array
+  ) {
+    throw new Error(
+      `Can not use native ${stringify(fnOrArray)} as constructor`
+    );
   }
 
   if (typeof fnOrArray === 'function') {
@@ -205,20 +231,17 @@ function applyParams(fnOrArray: Function|any[]|undefined, key: string): Function
     const fn: Function = fnOrArray[annoLength];
     if (typeof fn !== 'function') {
       throw new Error(
-          `Last position of Class method array must be Function in key ${key} was '${
-                                                                                     stringify(fn)
-                                                                                   }'`);
+        `Last position of Class method array must be Function in key ${key} was '${stringify(
+          fn
+        )}'`
+      );
     }
     if (annoLength != fn.length) {
       throw new Error(
-          `Number of annotations (${
-                                    annoLength
-                                  }) does not match number of arguments (${
-                                                                           fn.length
-                                                                         }) in the function: ${
-                                                                                               stringify(
-                                                                                                   fn)
-                                                                                             }`);
+        `Number of annotations (${annoLength}) does not match number of arguments (${fn.length}) in the function: ${stringify(
+          fn
+        )}`
+      );
     }
     const paramsAnnotations: any[][] = [];
     for (let i = 0, ii = annotations.length - 1; i < ii; i++) {
@@ -240,10 +263,10 @@ function applyParams(fnOrArray: Function|any[]|undefined, key: string): Function
   }
 
   throw new Error(
-      `Only Function or Array is supported in Class definition for key '${key}' is '${
-                                                                                      stringify(
-                                                                                          fnOrArray)
-                                                                                    }'`);
+    `Only Function or Array is supported in Class definition for key '${key}' is '${stringify(
+      fnOrArray
+    )}'`
+  );
 }
 
 /**
@@ -332,26 +355,32 @@ function applyParams(fnOrArray: Function|any[]|undefined, key: string): Function
  */
 export function Class(clsDef: ClassDefinition): Type<any> {
   const constructor = applyParams(
-      clsDef.hasOwnProperty('constructor') ? clsDef.constructor : undefined, 'constructor');
+    clsDef.hasOwnProperty('constructor') ? clsDef.constructor : undefined,
+    'constructor'
+  );
 
   let proto = constructor.prototype;
 
   if (clsDef.hasOwnProperty('extends')) {
     if (typeof clsDef.extends === 'function') {
-      (<Function>constructor).prototype = proto =
-          Object.create((<Function>clsDef.extends).prototype);
+      (<Function>constructor).prototype = proto = Object.create(
+        (<Function>clsDef.extends).prototype
+      );
     } else {
       throw new Error(
-          `Class definition 'extends' property must be a constructor function was: ${
-                                                                                     stringify(
-                                                                                         clsDef
-                                                                                             .extends)
-                                                                                   }`);
+        `Class definition 'extends' property must be a constructor function was: ${stringify(
+          clsDef.extends
+        )}`
+      );
     }
   }
 
   for (const key in clsDef) {
-    if (key !== 'extends' && key !== 'prototype' && clsDef.hasOwnProperty(key)) {
+    if (
+      key !== 'extends' &&
+      key !== 'prototype' &&
+      clsDef.hasOwnProperty(key)
+    ) {
       proto[key] = applyParams(clsDef[key], key);
     }
   }
@@ -372,8 +401,11 @@ export function Class(clsDef: ClassDefinition): Type<any> {
  * @suppress {globalThis}
  */
 export function makeDecorator(
-    name: string, props: {[name: string]: any}, parentClass?: any,
-    chainFn?: (fn: Function) => void): (...args: any[]) => (cls: any) => any {
+  name: string,
+  props: { [name: string]: any },
+  parentClass?: any,
+  chainFn?: (fn: Function) => void
+): (...args: any[]) => (cls: any) => any {
   const metaCtor = makeMetadataCtor([props]);
 
   function DecoratorFactory(objOrType: any): (cls: any) => any {
@@ -388,9 +420,13 @@ export function makeDecorator(
 
     const annotationInstance = new (<any>DecoratorFactory)(objOrType);
     const chainAnnotation =
-        typeof this === 'function' && Array.isArray(this.annotations) ? this.annotations : [];
+      typeof this === 'function' && Array.isArray(this.annotations)
+        ? this.annotations
+        : [];
     chainAnnotation.push(annotationInstance);
-    const TypeDecorator: TypeDecorator = <TypeDecorator>function TypeDecorator(cls: Type<any>) {
+    const TypeDecorator: TypeDecorator = <TypeDecorator>function TypeDecorator(
+      cls: Type<any>
+    ) {
       const annotations = Reflect.getOwnMetadata('annotations', cls) || [];
       annotations.push(annotationInstance);
       Reflect.defineMetadata('annotations', annotations, cls);
@@ -411,9 +447,10 @@ export function makeDecorator(
   return DecoratorFactory;
 }
 
-function makeMetadataCtor(props: ([string, any]|{[key: string]: any})[]): any {
+function makeMetadataCtor(
+  props: ([string, any] | { [key: string]: any })[]
+): any {
   return function ctor(...args: any[]) {
-
     props.forEach((prop, i) => {
       const argVal = args[i];
       if (Array.isArray(prop)) {
@@ -422,7 +459,9 @@ function makeMetadataCtor(props: ([string, any]|{[key: string]: any})[]): any {
       } else {
         for (const propName in prop) {
           this[propName] =
-              argVal && argVal.hasOwnProperty(propName) ? argVal[propName] : prop[propName];
+            argVal && argVal.hasOwnProperty(propName)
+              ? argVal[propName]
+              : prop[propName];
         }
       }
     });
@@ -430,7 +469,10 @@ function makeMetadataCtor(props: ([string, any]|{[key: string]: any})[]): any {
 }
 
 export function makeParamDecorator(
-    name: string, props: ([string, any]|{[name: string]: any})[], parentClass?: any): any {
+  name: string,
+  props: ([string, any] | { [name: string]: any })[],
+  parentClass?: any
+): any {
   const metaCtor = makeMetadataCtor(props);
   function ParamDecoratorFactory(...args: any[]): any {
     if (this instanceof ParamDecoratorFactory) {
@@ -443,7 +485,8 @@ export function makeParamDecorator(
     return ParamDecorator;
 
     function ParamDecorator(cls: any, unusedKey: any, index: number): any {
-      const parameters: (any[]|null)[] = Reflect.getOwnMetadata('parameters', cls) || [];
+      const parameters: (any[] | null)[] =
+        Reflect.getOwnMetadata('parameters', cls) || [];
 
       // there might be gaps if some in between parameters do not have
       // annotations. we pad with nulls.
@@ -467,7 +510,10 @@ export function makeParamDecorator(
 }
 
 export function makePropDecorator(
-    name: string, props: ([string, any]|{[key: string]: any})[], parentClass?: any): any {
+  name: string,
+  props: ([string, any] | { [key: string]: any })[],
+  parentClass?: any
+): any {
   const metaCtor = makeMetadataCtor(props);
 
   function PropDecoratorFactory(...args: any[]): any {
@@ -479,8 +525,9 @@ export function makePropDecorator(
     const decoratorInstance = new (<any>PropDecoratorFactory)(...args);
 
     return function PropDecorator(target: any, name: string) {
-      const meta = Reflect.getOwnMetadata('propMetadata', target.constructor) || {};
-      meta[name] = meta.hasOwnProperty(name) && meta[name] || [];
+      const meta =
+        Reflect.getOwnMetadata('propMetadata', target.constructor) || {};
+      meta[name] = (meta.hasOwnProperty(name) && meta[name]) || [];
       meta[name].unshift(decoratorInstance);
       Reflect.defineMetadata('propMetadata', meta, target.constructor);
     };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -3,7 +3,7 @@ import 'reflect-metadata';
 export function _normalizeRelations(providers: any[] = [], res: any = []) {
   providers.forEach(b => {
     if (typeof b === 'string') {
-      res.push({provide: b, useToken: b});
+      res.push({ provide: b, useToken: b });
     } else if (b && typeof b === 'object' && (b as any).provide !== undefined) {
       res.push(b);
     } else if (b instanceof Array) {
@@ -20,8 +20,9 @@ export function resolve(instance: any, providers: any[]) {
     if (typeof provider.useToken === 'string')
       return $resolve.call(instance, provider.useToken);
     else if (typeof provider.useFactory === 'function')
-      return $resolve.call(instance, provider.deps)
-          .then((resolved: any) => provider.useFactory.apply(instance, resolved));
+      return $resolve
+        .call(instance, provider.deps)
+        .then((resolved: any) => provider.useFactory.apply(instance, resolved));
   });
   return Promise.all(resolving);
 }
@@ -30,7 +31,8 @@ export function getAsync(relation: string) {
 }
 
 export function $resolve(dep: any = []) {
-  if (Array.isArray(dep)) return Promise.all(dep.map(d => $resolve.call(this, d)));
+  if (Array.isArray(dep))
+    return Promise.all(dep.map(d => $resolve.call(this, d)));
   switch (dep) {
     case '$model': {
       if (typeof this === 'object') {

--- a/src/lib/validate.ts
+++ b/src/lib/validate.ts
@@ -4,16 +4,29 @@ export const validateMetadataKey = Symbol('validates');
 
 const ValidationError = require('loopback').ValidationError;
 
-export function Validate(target: Object, propertyKey: string|symbol, parameterIndex: number) {
+export function Validate(
+  target: Object,
+  propertyKey: string | symbol,
+  parameterIndex: number
+) {
   let existingRequiredParameters: number[] =
-      Reflect.getOwnMetadata(validateMetadataKey, target.constructor, propertyKey) || [];
+    Reflect.getOwnMetadata(
+      validateMetadataKey,
+      target.constructor,
+      propertyKey
+    ) || [];
   existingRequiredParameters.push(parameterIndex);
   Reflect.defineMetadata(
-      validateMetadataKey, existingRequiredParameters, target.constructor, propertyKey);
+    validateMetadataKey,
+    existingRequiredParameters,
+    target.constructor,
+    propertyKey
+  );
 }
 
 export function validateArgs(args: any[], RemoteMethod: any) {
-  let validatesMeta = Reflect.getOwnMetadata(validateMetadataKey, RemoteMethod, 'onRemote') || [];
+  let validatesMeta =
+    Reflect.getOwnMetadata(validateMetadataKey, RemoteMethod, 'onRemote') || [];
   let validations = validatesMeta.map((idx: number) => getValid(args[idx]));
   return Promise.all(validations);
 }

--- a/src/test/create-event.spec.ts
+++ b/src/test/create-event.spec.ts
@@ -1,8 +1,8 @@
-import {expect} from 'chai';
-import {spy} from 'sinon';
+import { expect } from 'chai';
+import { spy } from 'sinon';
 
-import {ModelEvent} from '../';
-import {createEventMethod} from '../lib/create-event';
+import { ModelEvent } from '../';
+import { createEventMethod } from '../lib/create-event';
 
 describe('createEventMethod', () => {
   it('should bind to the class event listener', () => {
@@ -23,15 +23,17 @@ describe('createEventMethod', () => {
   });
 });
 
-const providers: any[] = [{provide: 'DankDep', useFactory: spy(() => 'Dankness provided')}];
+const providers: any[] = [
+  { provide: 'DankDep', useFactory: spy(() => 'Dankness provided') },
+];
 const eventSpy = spy(() => {});
-@ModelEvent({selector: 'before save', providers})
+@ModelEvent({ selector: 'before save', providers })
 class MockMethod {
   onEvent = eventSpy;
 }
 
 const mockModelFactory = () => {
   const mdl: any = {};
-  mdl.on = spy((event: string, cb: Function) => mdl.handler = cb);
+  mdl.on = spy((event: string, cb: Function) => (mdl.handler = cb));
   return mdl;
-}
+};

--- a/src/test/create-remote.spec.ts
+++ b/src/test/create-remote.spec.ts
@@ -1,9 +1,9 @@
-import {expect} from 'chai';
-import {spy} from 'sinon';
+import { expect } from 'chai';
+import { spy } from 'sinon';
 
 const loopback = require('loopback');
-import {createRemoteMethod} from '../lib/create-remote';
-import {Response, Validate} from '../index';
+import { createRemoteMethod } from '../lib/create-remote';
+import { Response, Validate } from '../index';
 
 describe('createRemoteMethod', () => {
   it('should handle a static method', () => {
@@ -11,14 +11,18 @@ describe('createRemoteMethod', () => {
     let props = mockProps();
     props.meta.isStatic = true;
     createRemoteMethod(mockClass, {}, props);
-    expect(mockClass).to.have.property('meth').and.to.be.a('function');
+    expect(mockClass)
+      .to.have.property('meth')
+      .and.to.be.a('function');
   });
 
   it('should handle an instance method', () => {
     const mockClass = mockClassFactory();
     let props = mockProps();
     createRemoteMethod(mockClass, {}, props);
-    expect(mockClass.prototype).to.have.property('meth').and.to.be.a('function');
+    expect(mockClass.prototype)
+      .to.have.property('meth')
+      .and.to.be.a('function');
   });
 
   it('should bind the remote method to the model', () => {
@@ -34,12 +38,15 @@ describe('createRemoteMethod', () => {
     const remoteSpy = spy(() => 'output');
     class remote {
       constructor(arg: any) {
-        expect(arg).to.eql('Dankness provided', 'should be provided the dependency');
+        expect(arg).to.eql(
+          'Dankness provided',
+          'should be provided the dependency'
+        );
       }
       public onRemote = remoteSpy;
     }
     createRemoteMethod(mockClass, remote, props);
-    let res = await(<any>mockClass).prototype.meth.call({}, 'dank');
+    let res = await (<any>mockClass).prototype.meth.call({}, 'dank');
     expect(remoteSpy.calledWith('dank')).to.be.true;
     expect(res).to.eql('output');
   });
@@ -48,19 +55,22 @@ describe('createRemoteMethod', () => {
     const mockClass = mockClassFactory();
     class remote {
       constructor(arg: any) {
-        expect(arg).to.eql('Dankness provided', 'should be provided the dependency');
+        expect(arg).to.eql(
+          'Dankness provided',
+          'should be provided the dependency'
+        );
       }
 
-      @Response({responseClass: 'User'})
+      @Response({ responseClass: 'User' })
       onRemote() {
         return {
-          username: 'Biff Tannen'
-        }
-      };
+          username: 'Biff Tannen',
+        };
+      }
     }
     createRemoteMethod(mockClass, remote, mockProps());
-    let res = await(<any>mockClass).prototype.meth.call({}, null);
-    expect(res).to.be.instanceof (loopback.User);
+    let res = await (<any>mockClass).prototype.meth.call({}, null);
+    expect(res).to.be.instanceof(loopback.User);
   });
 
   it('should validate any args marked as validatable', async () => {
@@ -68,22 +78,39 @@ describe('createRemoteMethod', () => {
     const remoteSpy = spy();
     class remote {
       constructor(arg: any) {
-        expect(arg).to.eql('Dankness provided', 'should be provided the dependency');
+        expect(arg).to.eql(
+          'Dankness provided',
+          'should be provided the dependency'
+        );
       }
 
       onRemote(@Validate user: any) {
         remoteSpy();
-      };
+      }
     }
     loopback.User.attachTo(loopback.memory());
     createRemoteMethod(mockClass, remote, mockProps());
-    let res = await expect((<any>mockClass).prototype.meth.call({}, new loopback.User({
-                email: 'not-an-email'
-              }))).to.eventually.be.rejectedWith(loopback.ValidationError);
+    let res = await expect(
+      (<any>mockClass).prototype.meth.call(
+        {},
+        new loopback.User({
+          email: 'not-an-email',
+        })
+      )
+    ).to.eventually.be.rejectedWith(loopback.ValidationError);
   });
 });
 
-const mockClassFactory = () => ({prototype: {}, remoteMethod: spy(() => true)});
+const mockClassFactory = () => ({
+  prototype: {},
+  remoteMethod: spy(() => true),
+});
 
-const providers: any = [{provide: 'DankDep', useFactory: () => 'Dankness provided'}];
-const mockProps = () => ({selector: 'meth', meta: {isStatic: false}, providers});
+const providers: any = [
+  { provide: 'DankDep', useFactory: () => 'Dankness provided' },
+];
+const mockProps = () => ({
+  selector: 'meth',
+  meta: { isStatic: false },
+  providers,
+});

--- a/src/test/decorator.spec.ts
+++ b/src/test/decorator.spec.ts
@@ -1,6 +1,6 @@
-import {expect} from 'chai';
+import { expect } from 'chai';
 
-import {RemoteMethodModule} from '../';
+import { RemoteMethodModule } from '../';
 
 const loopback = require('loopback');
 
@@ -12,9 +12,16 @@ describe('@RemoteMethodModule Decorator', () => {
     let decorated;
     before('Configure proxy', () => {
       const app = loopback();
-      internalModel = loopback.Model.extend(`Internal${Date.now()}`, {prop: 'string'}, {});
-      externalModel =
-          loopback.Model.extend(`External${Date.now()}`, {}, {idInjection: false, forceId: false});
+      internalModel = loopback.Model.extend(
+        `Internal${Date.now()}`,
+        { prop: 'string' },
+        {}
+      );
+      externalModel = loopback.Model.extend(
+        `External${Date.now()}`,
+        {},
+        { idInjection: false, forceId: false }
+      );
       let memory = loopback.memory();
       internalModel.attachTo(memory);
       externalModel.attachTo(memory);
@@ -23,7 +30,7 @@ describe('@RemoteMethodModule Decorator', () => {
 
       @RemoteMethodModule({
         proxyFor: internalModel.modelName,
-        proxyMethods: ['findById', 'prototype.updateAttributes']
+        proxyMethods: ['findById', 'prototype.updateAttributes'],
       })
       class ModelClass {
         constructor(public model: any) {}
@@ -34,7 +41,7 @@ describe('@RemoteMethodModule Decorator', () => {
     });
 
     before('Create instances', async () => {
-      instance = await internalModel.create({prop: 'hello'});
+      instance = await internalModel.create({ prop: 'hello' });
     });
 
     it('proxies a static method to a target internal model', async () => {
@@ -48,7 +55,7 @@ describe('@RemoteMethodModule Decorator', () => {
       // create an external model instance that will have the same id as the internal one
       let model = await externalModel.create();
       // save some changes which should trigger the save on the internal we proxy for
-      let updated = await model.updateAttributes({prop: 'goodbye'});
+      let updated = await model.updateAttributes({ prop: 'goodbye' });
       instance = await instance.reload();
       expect(instance).to.have.property('prop', 'goodbye');
     });
@@ -58,11 +65,16 @@ describe('@RemoteMethodModule Decorator', () => {
     let internalModel: any, externalModel: any, decorated: any, instance: any;
     before('Configure proxy', () => {
       const app = loopback();
-      internalModel =
-          loopback.Model.extend(`Internal${Date.now()}`, {secret: 'string', prop: 'string'}, {});
+      internalModel = loopback.Model.extend(
+        `Internal${Date.now()}`,
+        { secret: 'string', prop: 'string' },
+        {}
+      );
       externalModel = loopback.Model.extend(
-          `External${Date.now()}`, {prop: 'string'},
-          {strict: true, idInjection: false, forceId: false});
+        `External${Date.now()}`,
+        { prop: 'string' },
+        { strict: true, idInjection: false, forceId: false }
+      );
       let memory = loopback.memory();
       internalModel.attachTo(memory);
       externalModel.attachTo(memory);
@@ -72,7 +84,12 @@ describe('@RemoteMethodModule Decorator', () => {
       @RemoteMethodModule({
         proxyFor: internalModel.modelName,
         strict: true,
-        proxyMethods: ['find', 'findById', 'create', 'prototype.updateAttributes']
+        proxyMethods: [
+          'find',
+          'findById',
+          'create',
+          'prototype.updateAttributes',
+        ],
       })
       class ModelClass {
         constructor(public model: any) {}
@@ -83,12 +100,12 @@ describe('@RemoteMethodModule Decorator', () => {
     });
 
     before('Create instances', async () => {
-      instance = await internalModel.create({prop: 'hello'});
+      instance = await internalModel.create({ prop: 'hello' });
     });
 
     it('proxies findById to another model returning an instance of the proxy', async () => {
       let result = await externalModel.findById(instance.id);
-      expect(result).to.be.an.instanceof (externalModel);
+      expect(result).to.be.an.instanceof(externalModel);
       expect(result).to.have.property('prop', 'hello');
       expect(result).not.to.have.property('secret');
     });
@@ -96,18 +113,18 @@ describe('@RemoteMethodModule Decorator', () => {
       let result = await externalModel.find();
       expect(result).to.be.an('array');
       let item = result[0];
-      expect(item).to.be.an.instanceof (externalModel);
+      expect(item).to.be.an.instanceof(externalModel);
       expect(item).to.have.property('prop', 'hello');
       expect(item).not.to.have.property('secret');
     });
     it('proxies writes to the underlying model', async () => {
       let result = await externalModel.findById(instance.id);
-      await result.updateAttributes({prop: 'hi'});
+      await result.updateAttributes({ prop: 'hi' });
       let updated = await internalModel.findById(instance.id);
       expect(updated).to.have.property('prop', 'hi');
     });
     it('proxies creation to the underlying model', async () => {
-      let inst = await externalModel.create({prop: 'greetings'});
+      let inst = await externalModel.create({ prop: 'greetings' });
       let updated = await internalModel.findById(inst.id);
       expect(updated).to.have.property('prop', 'greetings');
     });

--- a/src/test/response.spec.ts
+++ b/src/test/response.spec.ts
@@ -1,87 +1,119 @@
-import {expect} from 'chai';
-import {spy} from 'sinon';
+import { expect } from 'chai';
+import { spy } from 'sinon';
 const loopback = require('loopback');
 
-import {Response} from '../index';
-import {buildResponse, mapResponse, responseMetadataKey} from '../lib/response';
+import { Response } from '../index';
+import {
+  buildResponse,
+  mapResponse,
+  responseMetadataKey,
+} from '../lib/response';
 
 describe('mapResponse', () => {
   it('should map a loopback instance to a response', () => {
     function responseClass(payload: any) {
-      this.result = payload.valid
-    };
-    let result = mapResponse(responseClass, {toJSON: () => ({invalid: 'foo', valid: 'bar'})});
+      this.result = payload.valid;
+    }
+    let result = mapResponse(responseClass, {
+      toJSON: () => ({ invalid: 'foo', valid: 'bar' }),
+    });
     expect(result).to.have.property('result', 'bar');
   });
 
   it('should map an POJO to a response', () => {
     function responseClass(payload: any) {
-      this.result = payload.valid
-    };
-    let result = mapResponse(responseClass, {invalid: 'foo', valid: 'bar'});
-    expect(result).to.have.property('result', 'bar')
+      this.result = payload.valid;
+    }
+    let result = mapResponse(responseClass, { invalid: 'foo', valid: 'bar' });
+    expect(result).to.have.property('result', 'bar');
   });
 });
 
 describe('buildResponse', () => {
   it('should work if no metadata exists', () => {
-    const result = {movie: 'Back to the Future'};
+    const result = { movie: 'Back to the Future' };
     const response = buildResponse(result, {});
     expect(response).to.equal(result);
   });
 
   it('should throw an error for models not defined on the registry', () => {
-    const result = {movie: 'Back to the Future'};
-    const remoteClass = {onRemote: () => {}};
+    const result = { movie: 'Back to the Future' };
+    const remoteClass = { onRemote: () => {} };
     Reflect.defineMetadata(
-        responseMetadataKey, {responseClass: 'NotReallyAModel'}, remoteClass, 'onRemote');
-    expect(buildResponse.bind(null, result, remoteClass))
-        .to.throw(`No model definition for NotReallyAModel found on the registry`);
+      responseMetadataKey,
+      { responseClass: 'NotReallyAModel' },
+      remoteClass,
+      'onRemote'
+    );
+    expect(buildResponse.bind(null, result, remoteClass)).to.throw(
+      `No model definition for NotReallyAModel found on the registry`
+    );
   });
 
   it('should work for single results', () => {
-    const result = {username: 'Marty McFly'};
+    const result = { username: 'Marty McFly' };
 
     class remoteClass {
       @Response('User')
       onRemote() {}
     }
     const response = buildResponse(result, remoteClass);
-    expect(response).to.be.an.instanceof (loopback.User);
+    expect(response).to.be.an.instanceof(loopback.User);
     expect(response).to.have.property('username', 'Marty McFly');
   });
 
   it('should work for array results', () => {
-    const result = [{username: 'Marty McFly'}, {username: 'Emmett Brown'}];
+    const result = [{ username: 'Marty McFly' }, { username: 'Emmett Brown' }];
     class remoteClass {
       @Response(['User'])
       onRemote() {}
     }
     const response: any[] = buildResponse(result, remoteClass);
-    expect(response).to.be.an('array').and.to.have.lengthOf(2);
-    response.forEach(res => expect(res).to.be.an.instanceof (loopback.User));
+    expect(response)
+      .to.be.an('array')
+      .and.to.have.lengthOf(2);
+    response.forEach(res => expect(res).to.be.an.instanceof(loopback.User));
   });
 
   context('Validation', () => {
     let ProxyModel: any, entity: any, withRelated: any;
     before(async () => {
       const InternalModelA = loopback.Model.extend(
-          'InternalModelA', {existsKey: 'string', privateKey: 'string'},
-          {strict: true, relations: {mb: {type: 'hasOne', model: 'InternalModelB'}}});
-      const InternalModelB = loopback.Model.extend('InternalModelB', {relatedKey: 'string'});
+        'InternalModelA',
+        { existsKey: 'string', privateKey: 'string' },
+        {
+          strict: true,
+          relations: { mb: { type: 'hasOne', model: 'InternalModelB' } },
+        }
+      );
+      const InternalModelB = loopback.Model.extend('InternalModelB', {
+        relatedKey: 'string',
+      });
       ProxyModel = loopback.Model.extend(
-          'ProxyModel', {existsKey: 'string', mb: 'InternalModelB'}, {strict: true});
-      [InternalModelA, InternalModelB, ProxyModel].forEach(mdl => mdl.attachTo(loopback.memory()));
-      let internal = await InternalModelA.create({existsKey: 'ok', privateKey: 'secret'});
-      await internal.mb.create({relatedKey: 'I am related'});
+        'ProxyModel',
+        { existsKey: 'string', mb: 'InternalModelB' },
+        { strict: true }
+      );
+      [InternalModelA, InternalModelB, ProxyModel].forEach(mdl =>
+        mdl.attachTo(loopback.memory())
+      );
+      let internal = await InternalModelA.create({
+        existsKey: 'ok',
+        privateKey: 'secret',
+      });
+      await internal.mb.create({ relatedKey: 'I am related' });
       entity = await InternalModelA.findOne();
-      withRelated = await InternalModelA.findOne({include: 'mb'});
+      withRelated = await InternalModelA.findOne({ include: 'mb' });
     });
 
     it('allows strict to filter out non-existant properties', () => {
       const response = mapResponse(ProxyModel, entity);
       // Should not have private key property
-      expect(response.toJSON()).to.eql({id: 1, existsKey: 'ok', mb: undefined});
+      expect(response.toJSON()).to.eql({
+        id: 1,
+        existsKey: 'ok',
+        mb: undefined,
+      });
     });
 
     it('works for model relations', async () => {
@@ -90,7 +122,7 @@ describe('buildResponse', () => {
       expect(response.toJSON()).to.eql({
         id: 1,
         existsKey: 'ok',
-        mb: {id: 1, internalModelAId: 1, relatedKey: 'I am related'}
+        mb: { id: 1, internalModelAId: 1, relatedKey: 'I am related' },
       });
     });
   });

--- a/src/test/utils.spec.ts
+++ b/src/test/utils.spec.ts
@@ -1,30 +1,36 @@
 import * as chai from 'chai';
 import * as promised from 'chai-as-promised';
 
-import {$resolve, _normalizeRelations, getAsync, resolve} from '../lib/utils';
+import { $resolve, _normalizeRelations, getAsync, resolve } from '../lib/utils';
 
 chai.use(promised);
-import {expect} from 'chai';
-import {spy} from 'sinon';
+import { expect } from 'chai';
+import { spy } from 'sinon';
 import 'mocha';
 
 describe('Normalize Relations', () => {
   it('should normalize string providers', () => {
     const res = _normalizeRelations(['myProvider']);
     expect(res).to.deep.equal(
-        [{provide: 'myProvider', useToken: 'myProvider'}], 'should turn it into an object');
+      [{ provide: 'myProvider', useToken: 'myProvider' }],
+      'should turn it into an object'
+    );
   });
 
   it('should add object providers', () => {
-    const provider = {provide: 'myProvider', useToken: 'someProvider'};
+    const provider = { provide: 'myProvider', useToken: 'someProvider' };
     const res = _normalizeRelations([provider]);
-    expect(res).to.be.an('array').and.to.contain(provider);
+    expect(res)
+      .to.be.an('array')
+      .and.to.contain(provider);
   });
 
   it('should normalize array providers', () => {
-    const provider = [{provide: 'myProvider', useToken: 'someProvider'}];
+    const provider = [{ provide: 'myProvider', useToken: 'someProvider' }];
     const res = _normalizeRelations([provider]);
-    expect(res).to.be.an('array').and.to.contain(provider[0]);
+    expect(res)
+      .to.be.an('array')
+      .and.to.contain(provider[0]);
   });
 
   it('should error an invalid provider', () => {
@@ -36,52 +42,68 @@ describe('Normalize Relations', () => {
 describe('$resolve', () => {
   it('should resolve the source model dep', async () => {
     const mockCtor = () => {};
-    const mockInstance = {constructor: mockCtor};
-    await expect($resolve.call(mockInstance, ['$model'])).to.eventually.eql([mockCtor]);
-    await expect($resolve.call(mockCtor, ['$model'])).to.eventually.eql([mockCtor]);
+    const mockInstance = { constructor: mockCtor };
+    await expect($resolve.call(mockInstance, ['$model'])).to.eventually.eql([
+      mockCtor,
+    ]);
+    await expect($resolve.call(mockCtor, ['$model'])).to.eventually.eql([
+      mockCtor,
+    ]);
   });
 
   it('should resolve an instance dep', async () => {
     const mockInstance = {};
-    await expect($resolve.call(mockInstance, ['$instance'])).to.eventually.eql([mockInstance]);
+    await expect($resolve.call(mockInstance, ['$instance'])).to.eventually.eql([
+      mockInstance,
+    ]);
   });
 
   it('should resolve the app', async () => {
     const app = {};
     const mockCtor = () => {};
     (<any>mockCtor).getApp = (cb: Function) => cb(null, app);
-    const mockInstance = {constructor: mockCtor};
-    await expect($resolve.call(mockInstance, ['$app'])).to.eventually.eql([app]);
+    const mockInstance = { constructor: mockCtor };
+    await expect($resolve.call(mockInstance, ['$app'])).to.eventually.eql([
+      app,
+    ]);
     await expect($resolve.call(mockCtor, ['$app'])).to.eventually.eql([app]);
   });
 
   it('should resolve a model dep', async () => {
-    const app = {models: {Danklords: {}}};
+    const app = { models: { Danklords: {} } };
     const mockCtor = () => {};
     (<any>mockCtor).getApp = (cb: Function) => cb(null, app);
-    const mockInstance = {constructor: mockCtor};
-    await expect($resolve.call(mockInstance, ['^Danklords'])).to.eventually.eql([
-      app.models.Danklords
+    const mockInstance = { constructor: mockCtor };
+    await expect(
+      $resolve.call(mockInstance, ['^Danklords'])
+    ).to.eventually.eql([app.models.Danklords]);
+    await expect($resolve.call(mockCtor, ['^Danklords'])).to.eventually.eql([
+      app.models.Danklords,
     ]);
-    await expect($resolve.call(mockCtor, ['^Danklords'])).to.eventually.eql([app.models.Danklords]);
   });
 
   it('should resolve a relation dep', async () => {
-    const mockInstance = {relations: {getAsync: () => Promise.resolve('Some relations')}};
-    await expect($resolve.call(mockInstance, ['relations'])).to.eventually.eql(['Some relations']);
+    const mockInstance = {
+      relations: { getAsync: () => Promise.resolve('Some relations') },
+    };
+    await expect($resolve.call(mockInstance, ['relations'])).to.eventually.eql([
+      'Some relations',
+    ]);
   });
 });
 
 describe('resolve', () => {
   it('should resolve a custom dep', async () => {
     const useFactory = () => Promise.resolve('Pretty dank');
-    await expect(resolve({}, [{provide: 'status', useFactory}])).to.eventually.eql(['Pretty dank']);
+    await expect(
+      resolve({}, [{ provide: 'status', useFactory }])
+    ).to.eventually.eql(['Pretty dank']);
   });
 });
 
 describe('getAsync', () => {
   it('should fetch the relation from the model', () => {
-    let mockModel = {relateds: {getAsync: spy(() => true)}};
+    let mockModel = { relateds: { getAsync: spy(() => true) } };
     expect(getAsync.call(mockModel, 'relateds')).to.be.ok;
     expect(mockModel.relateds.getAsync.calledOnce).to.be.ok;
   });

--- a/src/test/validate.spec.ts
+++ b/src/test/validate.spec.ts
@@ -1,9 +1,9 @@
 import 'reflect-metadata';
 
-import {expect} from 'chai';
-import {spy} from 'sinon';
-import {Validate} from '../';
-import {validateArgs, validateMetadataKey} from '../lib/validate';
+import { expect } from 'chai';
+import { spy } from 'sinon';
+import { Validate } from '../';
+import { validateArgs, validateMetadataKey } from '../lib/validate';
 const ValidationError = require('loopback').ValidationError;
 
 describe('@Validate', () => {
@@ -18,7 +18,7 @@ describe('@Validate', () => {
 
 describe('validateArgs / getValid', () => {
   it('should call the validate each of the validatable args', async () => {
-    const validatable = {isValid: spy((cb: Function) => cb(true))};
+    const validatable = { isValid: spy((cb: Function) => cb(true)) };
     class Remote {
       onRemote(app: any, @Validate payload: any = validatable) {}
     }
@@ -30,13 +30,14 @@ describe('validateArgs / getValid', () => {
     const validatable = {
       errors: ['not dank enough'],
       isValid: spy((cb: Function) => cb(false)),
-      toJSON: () => {}
+      toJSON: () => {},
     };
     class Remote {
       onRemote(app: any, @Validate payload: any = validatable) {}
     }
-    await expect(validateArgs([{}, validatable], Remote))
-        .to.eventually.be.rejectedWith(ValidationError);
+    await expect(
+      validateArgs([{}, validatable], Remote)
+    ).to.eventually.be.rejectedWith(ValidationError);
     expect(validatable.isValid.calledOnce).to.be.true;
   });
-})
+});


### PR DESCRIPTION
This pull request replaces clang-format as the repositorys formatter with [prettier](https://prettier.io/). No changes to functionality have been made, purely aesthetic.

![aesthetic](http://i0.kym-cdn.com/photos/images/masonry/001/153/016/050.jpg)

